### PR TITLE
add: typescript相关配置

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,1 +1,7 @@
-module.exports = { extends: ["./packages/base/index.js", "./packages/vue2/index.js"] };
+module.exports = { 
+  extends: [
+  "./packages/base/index.js", 
+  "./packages/vue2/index.js",
+  "./packages/typescript/index.js"
+] 
+};

--- a/packages/typescript/README.md
+++ b/packages/typescript/README.md
@@ -1,0 +1,95 @@
+![](https://img.shields.io/npm/v/@charrue/eslint-config-base.svg)![](https://img.shields.io/npm/dt/@charrue/eslint-config-base.svg)![](https://img.shields.io/npm/l/express.svg)
+
+
+# @charrue/eslint-config-typescript
+
+此规则是参考[apptools-lab](https://github.com/apptools-lab/AppLint/tree/main/packages/eslint-config)实现的。
+
+
+
+## 使用
+
+### 下载
+
+```bash
+# npm
+npm install @charrue/eslint-config-typescript
+
+# yarn
+yarn add @charrue/eslint-config-typescript
+
+# pnpm
+pnpm add @charrue/eslint-config-typescript
+```
+
+
+
+### 配置
+
+使用`.eslintrc.js`进行规则配置
+```js
+module.exports = {
+  root: true,
+  extends: [
+    '@charrue/typescript',
+  ],
+  rules: {
+    // override/add rules settings
+  }
+}
+```
+
+
+
+### 规则
+
+| 规则                                    | 说明                                                         |
+| --------------------------------------- | ------------------------------------------------------------ |
+| lines-between-class-members             | 在类重载后不跳过检查空行                                     |
+| no-confusing-non-null-assertion         | 禁止使用容易混淆的非空断言                                   |
+| prefer-nullish-coalescing               | 使用可选链式表达式而不是逻辑与运算符<br />比如：使用 a?.b 代替 a && a.b，语法上更简洁 |
+| no-non-null-asserted-nullish-coalescing | 不允许非空断言与空值合并同时使用                             |
+| space-infix-ops                         | 运算符两侧需要有空格，并增加对枚举类型支持                   |
+| keyword-spacing                         | 关键字前后有一个空格，并增加了对函数调用的泛型类型参数的支持 |
+| type-annotation-spacing                 | 调用函数时，函数名与括号之间没有空格，并增加了对函数调用的泛型类型参数的支持 |
+| func-call-spacing                       | 变量命名不能和关键字同名                                     |
+| comma-spacing                           | 逗号前面没空格，后面有空格                                   |
+| space-before-function-paren             | 增加了对函数调用的泛型类型参数的支持                         |
+| member-delimiter-style                  | interface 和 type 里的成员统一使用分号（;）进行分割，单行类型的最后一个元素不加分号 |
+| brace-style                             | 对于非空代码块，采用 Egyptian Brackets 风格                  |
+| no-array-constructor                    | 不要使用 new Array() 和 Array() 创建数组，除非为了构造某一长度的空数组 |
+| no-unused-vars                          | 使用的变量                                                   |
+| ban-types                               | 禁止部分值被作为类型标注，需要对每一种被禁用的类型提供特定的说明 |
+| no-confusing-void-expression            | 不允许返回一个类型是 void 的表达式                           |
+| no-inferrable-types                     | 不允许不必要的类型标注，但允许类的属性成员进行额外标注       |
+| no-unnecessary-type-arguments           | 使用泛型时，不允许指定与默认类型参数一致的类型参数           |
+| no-unnecessary-type-constraint          | 不允许与默认约束一致的泛型约束<br />在 TS 3.9 版本以后，对于未指定的泛型约束，默认使用 unknown ，在这之前则是 any |
+| no-non-null-asserted-optional-chain     | 不允许非空断言与可选链同时使用                               |
+| prefer-for-of                           | 如果索引仅用于访问正在迭代的数组，则首选 for...of 而不是 for 循环遍历数组 |
+| adjacent-overload-signatures            | 重载的函数写在一起                                           |
+| default-param-last                      | 具有默认值的函数参数应该被放置到参数列表右边                 |
+| explicit-member-accessibility           | 设置类的成员的可访问性，public 可省略                        |
+| prefer-literal-enum-member              | 对于枚举成员值，只允许使用普通字符串、数字、null、正则，而不允许变量复制、模板字符串等需要计算的操作 |
+| await-thenable                          | 只允许对异步函数、Promise、PromiseLike 使用 await 调用       |
+| promise-function-async                  | 返回 Promise 的函数必须被标记为 async                        |
+| consistent-type-imports                 | 约束使用 import type {} 进行类型的导入                       |
+| no-duplicate-imports                    | 不允许对同一模块重复导入，类型可重复导入                     |
+| prefer-namespace-keyword                | 禁止使用 module 来定义命名空间                               |
+| method-signature-style                  | 接口中的方法使用属性的方式定义。使用属性去定义接口中的方法，可以获得更严格的检查 |
+| no-empty-interface                      | 不允许定义空的接口，允许单继承下的空接口                     |
+| consistent-type-definitions             | 对于对象类型，优先使用 interface 定义                        |
+| no-extra-non-null-assertion             | 不允许额外的非空断言                                         |
+| no-unnecessary-type-assertion           | 不允许与实际值一致的类型断言                                 |
+| non-nullable-type-assertion-style       | 首选非空断言而不是显式类型转换                               |
+| consistent-type-assertions              | 使用 as 进行类型断言而不是 <>                                |
+| ban-tslint-comment                      | 禁止使用 `tslint:<rule-flag>` 等相关注释，tslint 已经不再维护了 |
+| ban-ts-comment                          | 禁止使用其他 @ts 规则，除非提供必要的说明                    |
+| prefer-ts-expect-error                  | 推荐使用 ts-expect-error 而不是 ts-ignore                    |
+
+
+
+
+
+
+
+

--- a/packages/typescript/index.js
+++ b/packages/typescript/index.js
@@ -1,0 +1,6 @@
+module.exports = {
+  extends: [
+    "plugin:@typescript-eslint/recommended",
+    "./typescripte.js",
+  ],
+};

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@charrue/eslint-config-typescript",
+  "version": "0.1.0",
+  "description": "",
+  "main": "index.js",
+  "homepage": "https://github.com/charrue/configs/blob/master/packages/typescript/README.md",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/charrue/configs.git"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  },
+  "keywords": [
+    "eslint",
+    "linter",
+    "charrue"
+  ],
+  "author": "ckangwen",
+  "license": "MIT",
+  "devDependencies": {
+    "eslint": "^8.6.0"
+  },
+  "dependencies": {
+    "@typescript-eslint/parser": "^5.11.0",
+    "@typescript-eslint/eslint-plugin": "^5.11.0"
+  }
+}

--- a/packages/typescript/typescript.js
+++ b/packages/typescript/typescript.js
@@ -1,0 +1,198 @@
+module.exports = {
+
+  parser: '@typescript-eslint/parser',
+  plugins: ['@typescript-eslint'],
+  settings: {
+    // 增加 ts 文件后缀
+    'import/parsers': {
+      '@typescript-eslint/parser': ['.ts', '.d.ts'],
+    },
+    // 增加 ts 文件后缀
+    'import/resolver': {
+      node: {
+        extensions: ['.mjs', '.js', '.ts', '.json'],
+      },
+    },
+    // 增加 ts 文件后缀
+    'import/extensions': ['.js', '.ts', '.mjs'],
+  },
+  parserOptions: {
+    project: './tsconfig.json',
+    createDefaultProgram: true, // 兼容未在 tsconfig.json 中包含的文件
+    extraFileExtensions: ['.vue'],
+  },
+  rules: {
+    // 在类重载后不跳过检查空行
+    'lines-between-class-members': 'off',
+    '@typescript-eslint/lines-between-class-members': [
+      'error',
+      'always',
+      {
+        exceptAfterSingleLine: false,
+      },
+    ],
+
+
+    // 运算符两侧需要有空格，并增加对枚举类型支持
+    'space-infix-ops': 'off',
+    '@typescript-eslint/space-infix-ops': ['error', { int32Hint: false }],
+
+    // 关键字前后有一个空格，并增加了对函数调用的泛型类型参数的支持。
+    'keyword-spacing': 'off',
+    '@typescript-eslint/keyword-spacing': 'error',
+
+    // 指定类型时应该正确添加空格
+    '@typescript-eslint/type-annotation-spacing': 'error',
+
+    // 调用函数时，函数名与括号之间没有空格，并增加了对函数调用的泛型类型参数的支持
+    'func-call-spacing': 'off',
+    '@typescript-eslint/func-call-spacing': 'error',
+
+    // 逗号前面没空格，后面有空格
+    'comma-spacing': 'off',
+    '@typescript-eslint/comma-spacing': 'error',
+
+    // 函数声明时，对于命名函数，参数的小括号前无空格；对于匿名函数和 async 箭头函数，参数的小括号前有空格
+    // 增加了对函数调用的泛型类型参数的支持
+    'space-before-function-paren': 'off',
+    '@typescript-eslint/space-before-function-paren': [
+      'error',
+      {
+        named: 'never',
+        anonymous: 'always',
+        asyncArrow: 'always',
+      },
+    ],
+
+    // interface 和 type 里的成员统一使用分号（;）进行分割，单行类型的最后一个元素不加分号
+    '@typescript-eslint/member-delimiter-style': 'error',
+
+
+
+    // 对于非空代码块，采用 Egyptian Brackets 风格
+    // 增加对 enum、interface、namespace、module 的支持
+    'brace-style': 'off',
+    '@typescript-eslint/brace-style': 'error',
+
+    // 不要使用 new Array() 和 Array() 创建数组，除非为了构造某一长度的空数组
+    'no-array-constructor': 'off',
+    '@typescript-eslint/no-array-constructor': ['error'],
+
+    'no-unused-vars': 'off',
+    '@typescript-eslint/no-unused-vars': ['warn', {
+      vars: 'all', args: 'after-used', ignoreRestSiblings: true,
+    }],
+    // 禁止部分值被作为类型标注，需要对每一种被禁用的类型提供特定的说明
+    // 1. 不使用大写的原始类型，应该使用小写的类型
+    // 2. 对于对象类型，应使用 Record<string, unknown>，而不是 object
+    // 3. 对于函数类型，应使用入参和返回值被标注的具体类型
+    '@typescript-eslint/ban-types': 'error',
+
+    // 不允许返回一个类型是 void 的表达式
+    '@typescript-eslint/no-confusing-void-expression': 'error',
+
+    // 不允许不必要的类型标注，但允许类的属性成员进行额外标注
+    '@typescript-eslint/no-inferrable-types': 'error',
+
+    // 使用泛型时，不允许指定与默认类型参数一致的类型参数
+    '@typescript-eslint/no-unnecessary-type-arguments': 'error',
+
+    // 不允许与默认约束一致的泛型约束
+    // 在 TS 3.9 版本以后，对于未指定的泛型约束，默认使用 unknown ，在这之前则是 any
+    '@typescript-eslint/no-unnecessary-type-constraint': 'error',
+
+    // 使用可选链式表达式而不是逻辑与运算符
+    // 比如：使用 a?.b 代替 a && a.b，语法上更简洁
+    '@typescript-eslint/prefer-nullish-coalescing': 'warn',
+
+    // 不允许非空断言与空值合并同时使用
+    '@typescript-eslint/no-non-null-asserted-nullish-coalescing': 'warn',
+
+    // 不允许非空断言与可选链同时使用
+    '@typescript-eslint/no-non-null-asserted-optional-chain': 'warn',
+
+    // 如果索引仅用于访问正在迭代的数组，则首选 for...of 而不是 for 循环遍历数组
+    '@typescript-eslint/prefer-for-of': 'warn',
+
+    //  重载的函数写在一起
+    '@typescript-eslint/adjacent-overload-signatures': 'warn',
+
+    // 具有默认值的函数参数应该被放置到参数列表右边
+    '@typescript-eslint/default-param-last': 'warn',
+
+    // 设置类的成员的可访问性，public 可省略
+    '@typescript-eslint/explicit-member-accessibility': [
+      'warn',
+    ],
+
+    // 对于枚举成员值，只允许使用普通字符串、数字、null、正则，而不允许变量复制、模板字符串等需要计算的操作
+    '@typescript-eslint/prefer-literal-enum-member': 'warn',
+
+    // 只允许对异步函数、Promise、PromiseLike 使用 await 调用
+    '@typescript-eslint/await-thenable': 'warn',
+
+    // 返回 Promise 的函数必须被标记为 async
+    '@typescript-eslint/promise-function-async': 'error',
+
+    // 约束使用 import type {} 进行类型的导入
+    '@typescript-eslint/consistent-type-imports': 'error',
+
+    // 不允许对同一模块重复导入，类型可重复导入
+    'no-duplicate-imports': 'off',
+    '@typescript-eslint/no-duplicate-imports': 'warn',
+
+    // 禁止使用 module 来定义命名空间
+    '@typescript-eslint/prefer-namespace-keyword': 'error',
+
+    // 接口中的方法使用属性的方式定义。使用属性去定义接口中的方法，可以获得更严格的检查
+    '@typescript-eslint/method-signature-style': 'error',
+
+    // 不允许定义空的接口，允许单继承下的空接口
+    '@typescript-eslint/no-empty-interface': 'warn',
+
+    // 对于对象类型，优先使用 interface 定义
+    '@typescript-eslint/consistent-type-definitions': ['error', 'interface'],
+
+    // 禁止使用容易混淆的非空断言
+    '@typescript-eslint/no-confusing-non-null-assertion': 'error',
+
+    // 不允许额外的非空断言
+    '@typescript-eslint/no-extra-non-null-assertion': 'error',
+
+    // 不允许与实际值一致的类型断言
+    '@typescript-eslint/no-unnecessary-type-assertion': 'error',
+
+    // 首选非空断言而不是显式类型转换
+    '@typescript-eslint/non-nullable-type-assertion-style': 'error',
+
+    // 使用 as 进行类型断言而不是 <>
+    '@typescript-eslint/consistent-type-assertions': 'warn',
+
+    // 禁止使用 tslint:<rule-flag> 等相关注释，tslint 已经不再维护了
+    '@typescript-eslint/ban-tslint-comment': 'error',
+
+    // 禁止使用其他 @ts 规则，除非提供必要的说明。
+    '@typescript-eslint/ban-ts-comment': 'warn',
+
+    // 推荐使用 ts-expect-error 而不是 ts-ignore
+    '@typescript-eslint/prefer-ts-expect-error': 'error',
+  },
+  overrides: [
+    {
+      files: ['*.ts', '*.tsx'],
+      rules: {
+        // Disable `no-undef` rule within TypeScript files
+        // because it incorrectly errors when exporting default interfaces
+        // https://github.com/iamturns/eslint-config-airbnb-typescript/issues/50
+        // This will be caught by TypeScript compiler if `strictNullChecks` (or `strict`) is enabled
+        'no-undef': 'off',
+
+        /* Using TypeScript makes it safe enough to disable the checks below */
+
+        // Disable ESLint-based module resolution check for improved monorepo support
+        // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-unresolved.md
+        'import/no-unresolved': 'off',
+      },
+    },
+  ],
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,17 @@ importers:
     devDependencies:
       eslint: registry.npmmirror.com/eslint/8.8.0
 
+  packages/typescript:
+    specifiers:
+      '@typescript-eslint/eslint-plugin': ^5.11.0
+      '@typescript-eslint/parser': ^5.11.0
+      eslint: ^8.6.0
+    dependencies:
+      '@typescript-eslint/eslint-plugin': registry.npmmirror.com/@typescript-eslint/eslint-plugin/5.14.0_bc38af3d60ca543c620734b1f2c72e6c
+      '@typescript-eslint/parser': registry.npmmirror.com/@typescript-eslint/parser/5.14.0_eslint@8.8.0
+    devDependencies:
+      eslint: registry.npmmirror.com/eslint/8.8.0
+
   packages/vue-base:
     specifiers:
       eslint: ^8.6.0
@@ -52,12 +63,6 @@ packages:
     name: cachedir
     version: 2.2.0
     engines: {node: '>=6'}
-    dev: true
-
-  registry.nlark.com/concat-map/0.0.1:
-    resolution: {integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=, registry: https://registry.npm.taobao.org/, tarball: https://registry.nlark.com/concat-map/download/concat-map-0.0.1.tgz}
-    name: concat-map
-    version: 0.0.1
     dev: true
 
   registry.nlark.com/detect-indent/6.0.0:
@@ -233,6 +238,33 @@ packages:
     version: 1.2.1
     dev: true
 
+  registry.npmmirror.com/@nodelib/fs.scandir/2.1.5:
+    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==, registry: https://registry.npm.taobao.org/, tarball: https://registry.npmmirror.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz}
+    name: '@nodelib/fs.scandir'
+    version: 2.1.5
+    engines: {node: '>= 8'}
+    dependencies:
+      '@nodelib/fs.stat': registry.npmmirror.com/@nodelib/fs.stat/2.0.5
+      run-parallel: registry.npmmirror.com/run-parallel/1.2.0
+    dev: false
+
+  registry.npmmirror.com/@nodelib/fs.stat/2.0.5:
+    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==, registry: https://registry.npm.taobao.org/, tarball: https://registry.npmmirror.com/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz}
+    name: '@nodelib/fs.stat'
+    version: 2.0.5
+    engines: {node: '>= 8'}
+    dev: false
+
+  registry.npmmirror.com/@nodelib/fs.walk/1.2.8:
+    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==, registry: https://registry.npm.taobao.org/, tarball: https://registry.npmmirror.com/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz}
+    name: '@nodelib/fs.walk'
+    version: 1.2.8
+    engines: {node: '>= 8'}
+    dependencies:
+      '@nodelib/fs.scandir': registry.npmmirror.com/@nodelib/fs.scandir/2.1.5
+      fastq: registry.npmmirror.com/fastq/1.13.0
+    dev: false
+
   registry.npmmirror.com/@tsconfig/node10/1.0.8:
     resolution: {integrity: sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==, registry: https://registry.npm.taobao.org/, tarball: https://registry.npmmirror.com/@tsconfig/node10/-/node10-1.0.8.tgz}
     name: '@tsconfig/node10'
@@ -261,12 +293,160 @@ packages:
     dev: true
     optional: true
 
+  registry.npmmirror.com/@types/json-schema/7.0.9:
+    resolution: {integrity: sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==, registry: https://registry.npm.taobao.org/, tarball: https://registry.npmmirror.com/@types/json-schema/-/json-schema-7.0.9.tgz}
+    name: '@types/json-schema'
+    version: 7.0.9
+    dev: false
+
   registry.npmmirror.com/@types/parse-json/4.0.0:
     resolution: {integrity: sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==, registry: https://registry.npm.taobao.org/, tarball: https://registry.npmmirror.com/@types/parse-json/-/parse-json-4.0.0.tgz}
     name: '@types/parse-json'
     version: 4.0.0
     dev: true
     optional: true
+
+  registry.npmmirror.com/@typescript-eslint/eslint-plugin/5.14.0_bc38af3d60ca543c620734b1f2c72e6c:
+    resolution: {integrity: sha512-ir0wYI4FfFUDfLcuwKzIH7sMVA+db7WYen47iRSaCGl+HMAZI9fpBwfDo45ZALD3A45ZGyHWDNLhbg8tZrMX4w==, registry: https://registry.npm.taobao.org/, tarball: https://registry.npmmirror.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.14.0.tgz}
+    id: registry.npmmirror.com/@typescript-eslint/eslint-plugin/5.14.0
+    name: '@typescript-eslint/eslint-plugin'
+    version: 5.14.0
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^5.0.0
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/parser': registry.npmmirror.com/@typescript-eslint/parser/5.14.0_eslint@8.8.0
+      '@typescript-eslint/scope-manager': registry.npmmirror.com/@typescript-eslint/scope-manager/5.14.0
+      '@typescript-eslint/type-utils': registry.npmmirror.com/@typescript-eslint/type-utils/5.14.0_eslint@8.8.0
+      '@typescript-eslint/utils': registry.npmmirror.com/@typescript-eslint/utils/5.14.0_eslint@8.8.0
+      debug: registry.npmmirror.com/debug/4.3.3
+      eslint: registry.npmmirror.com/eslint/8.8.0
+      functional-red-black-tree: registry.npmmirror.com/functional-red-black-tree/1.0.1
+      ignore: registry.npmmirror.com/ignore/5.2.0
+      regexpp: registry.npmmirror.com/regexpp/3.2.0
+      semver: registry.npmmirror.com/semver/7.3.5
+      tsutils: registry.npmmirror.com/tsutils/3.21.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  registry.npmmirror.com/@typescript-eslint/parser/5.14.0_eslint@8.8.0:
+    resolution: {integrity: sha512-aHJN8/FuIy1Zvqk4U/gcO/fxeMKyoSv/rS46UXMXOJKVsLQ+iYPuXNbpbH7cBLcpSbmyyFbwrniLx5+kutu1pw==, registry: https://registry.npm.taobao.org/, tarball: https://registry.npmmirror.com/@typescript-eslint/parser/-/parser-5.14.0.tgz}
+    id: registry.npmmirror.com/@typescript-eslint/parser/5.14.0
+    name: '@typescript-eslint/parser'
+    version: 5.14.0
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/scope-manager': registry.npmmirror.com/@typescript-eslint/scope-manager/5.14.0
+      '@typescript-eslint/types': registry.npmmirror.com/@typescript-eslint/types/5.14.0
+      '@typescript-eslint/typescript-estree': registry.npmmirror.com/@typescript-eslint/typescript-estree/5.14.0
+      debug: registry.npmmirror.com/debug/4.3.3
+      eslint: registry.npmmirror.com/eslint/8.8.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  registry.npmmirror.com/@typescript-eslint/scope-manager/5.14.0:
+    resolution: {integrity: sha512-LazdcMlGnv+xUc5R4qIlqH0OWARyl2kaP8pVCS39qSL3Pd1F7mI10DbdXeARcE62sVQE4fHNvEqMWsypWO+yEw==, registry: https://registry.npm.taobao.org/, tarball: https://registry.npmmirror.com/@typescript-eslint/scope-manager/-/scope-manager-5.14.0.tgz}
+    name: '@typescript-eslint/scope-manager'
+    version: 5.14.0
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      '@typescript-eslint/types': registry.npmmirror.com/@typescript-eslint/types/5.14.0
+      '@typescript-eslint/visitor-keys': registry.npmmirror.com/@typescript-eslint/visitor-keys/5.14.0
+    dev: false
+
+  registry.npmmirror.com/@typescript-eslint/type-utils/5.14.0_eslint@8.8.0:
+    resolution: {integrity: sha512-d4PTJxsqaUpv8iERTDSQBKUCV7Q5yyXjqXUl3XF7Sd9ogNLuKLkxz82qxokqQ4jXdTPZudWpmNtr/JjbbvUixw==, registry: https://registry.npm.taobao.org/, tarball: https://registry.npmmirror.com/@typescript-eslint/type-utils/-/type-utils-5.14.0.tgz}
+    id: registry.npmmirror.com/@typescript-eslint/type-utils/5.14.0
+    name: '@typescript-eslint/type-utils'
+    version: 5.14.0
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: '*'
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/utils': registry.npmmirror.com/@typescript-eslint/utils/5.14.0_eslint@8.8.0
+      debug: registry.npmmirror.com/debug/4.3.3
+      eslint: registry.npmmirror.com/eslint/8.8.0
+      tsutils: registry.npmmirror.com/tsutils/3.21.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  registry.npmmirror.com/@typescript-eslint/types/5.14.0:
+    resolution: {integrity: sha512-BR6Y9eE9360LNnW3eEUqAg6HxS9Q35kSIs4rp4vNHRdfg0s+/PgHgskvu5DFTM7G5VKAVjuyaN476LCPrdA7Mw==, registry: https://registry.npm.taobao.org/, tarball: https://registry.npmmirror.com/@typescript-eslint/types/-/types-5.14.0.tgz}
+    name: '@typescript-eslint/types'
+    version: 5.14.0
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dev: false
+
+  registry.npmmirror.com/@typescript-eslint/typescript-estree/5.14.0:
+    resolution: {integrity: sha512-QGnxvROrCVtLQ1724GLTHBTR0lZVu13izOp9njRvMkCBgWX26PKvmMP8k82nmXBRD3DQcFFq2oj3cKDwr0FaUA==, registry: https://registry.npm.taobao.org/, tarball: https://registry.npmmirror.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.14.0.tgz}
+    name: '@typescript-eslint/typescript-estree'
+    version: 5.14.0
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/types': registry.npmmirror.com/@typescript-eslint/types/5.14.0
+      '@typescript-eslint/visitor-keys': registry.npmmirror.com/@typescript-eslint/visitor-keys/5.14.0
+      debug: registry.npmmirror.com/debug/4.3.3
+      globby: registry.npmmirror.com/globby/11.1.0
+      is-glob: registry.npmmirror.com/is-glob/4.0.3
+      semver: registry.npmmirror.com/semver/7.3.5
+      tsutils: registry.npmmirror.com/tsutils/3.21.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  registry.npmmirror.com/@typescript-eslint/utils/5.14.0_eslint@8.8.0:
+    resolution: {integrity: sha512-EHwlII5mvUA0UsKYnVzySb/5EE/t03duUTweVy8Zqt3UQXBrpEVY144OTceFKaOe4xQXZJrkptCf7PjEBeGK4w==, registry: https://registry.npm.taobao.org/, tarball: https://registry.npmmirror.com/@typescript-eslint/utils/-/utils-5.14.0.tgz}
+    id: registry.npmmirror.com/@typescript-eslint/utils/5.14.0
+    name: '@typescript-eslint/utils'
+    version: 5.14.0
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      '@types/json-schema': registry.npmmirror.com/@types/json-schema/7.0.9
+      '@typescript-eslint/scope-manager': registry.npmmirror.com/@typescript-eslint/scope-manager/5.14.0
+      '@typescript-eslint/types': registry.npmmirror.com/@typescript-eslint/types/5.14.0
+      '@typescript-eslint/typescript-estree': registry.npmmirror.com/@typescript-eslint/typescript-estree/5.14.0
+      eslint: registry.npmmirror.com/eslint/8.8.0
+      eslint-scope: registry.npmmirror.com/eslint-scope/5.1.1
+      eslint-utils: registry.npmmirror.com/eslint-utils/3.0.0_eslint@8.8.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: false
+
+  registry.npmmirror.com/@typescript-eslint/visitor-keys/5.14.0:
+    resolution: {integrity: sha512-yL0XxfzR94UEkjBqyymMLgCBdojzEuy/eim7N9/RIcTNxpJudAcqsU8eRyfzBbcEzGoPWfdM3AGak3cN08WOIw==, registry: https://registry.npm.taobao.org/, tarball: https://registry.npmmirror.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.14.0.tgz}
+    name: '@typescript-eslint/visitor-keys'
+    version: 5.14.0
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      '@typescript-eslint/types': registry.npmmirror.com/@typescript-eslint/types/5.14.0
+      eslint-visitor-keys: registry.npmmirror.com/eslint-visitor-keys/3.2.0
+    dev: false
 
   registry.npmmirror.com/acorn-jsx/5.3.2_acorn@8.7.0:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==, registry: https://registry.npm.taobao.org/, tarball: https://registry.npmmirror.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz}
@@ -363,6 +543,13 @@ packages:
     version: 2.0.1
     dev: true
 
+  registry.npmmirror.com/array-union/2.1.0:
+    resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==, registry: https://registry.npm.taobao.org/, tarball: https://registry.npmmirror.com/array-union/-/array-union-2.1.0.tgz}
+    name: array-union
+    version: 2.1.0
+    engines: {node: '>=8'}
+    dev: false
+
   registry.npmmirror.com/balanced-match/1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==, registry: https://registry.npm.taobao.org/, tarball: https://registry.npmmirror.com/balanced-match/-/balanced-match-1.0.2.tgz}
     name: balanced-match
@@ -375,7 +562,7 @@ packages:
     version: 1.1.11
     dependencies:
       balanced-match: registry.npmmirror.com/balanced-match/1.0.2
-      concat-map: registry.nlark.com/concat-map/0.0.1
+      concat-map: registry.npmmirror.com/concat-map/0.0.1
     dev: true
 
   registry.npmmirror.com/braces/3.0.2:
@@ -385,7 +572,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       fill-range: registry.npmmirror.com/fill-range/7.0.1
-    dev: true
 
   registry.npmmirror.com/callsites/3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==, registry: https://registry.npm.taobao.org/, tarball: https://registry.npmmirror.com/callsites/-/callsites-3.1.0.tgz}
@@ -490,6 +676,12 @@ packages:
       - '@swc/core'
       - '@swc/wasm'
       - '@types/node'
+    dev: true
+
+  registry.npmmirror.com/concat-map/0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==, registry: https://registry.npm.taobao.org/, tarball: https://registry.npmmirror.com/concat-map/-/concat-map-0.0.1.tgz}
+    name: concat-map
+    version: 0.0.1
     dev: true
 
   registry.npmmirror.com/conventional-commit-types/3.0.0:
@@ -629,6 +821,15 @@ packages:
     dev: true
     optional: true
 
+  registry.npmmirror.com/dir-glob/3.0.1:
+    resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==, registry: https://registry.npm.taobao.org/, tarball: https://registry.npmmirror.com/dir-glob/-/dir-glob-3.0.1.tgz}
+    name: dir-glob
+    version: 3.0.1
+    engines: {node: '>=8'}
+    dependencies:
+      path-type: registry.npmmirror.com/path-type/4.0.0
+    dev: false
+
   registry.npmmirror.com/doctrine/3.0.0:
     resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==, registry: https://registry.npm.taobao.org/, tarball: https://registry.npmmirror.com/doctrine/-/doctrine-3.0.0.tgz}
     name: doctrine
@@ -677,6 +878,16 @@ packages:
       vue-eslint-parser: registry.npmmirror.com/vue-eslint-parser/8.2.0_eslint@8.8.0
     transitivePeerDependencies:
       - supports-color
+    dev: false
+
+  registry.npmmirror.com/eslint-scope/5.1.1:
+    resolution: {integrity: sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==, registry: https://registry.npm.taobao.org/, tarball: https://registry.npmmirror.com/eslint-scope/-/eslint-scope-5.1.1.tgz}
+    name: eslint-scope
+    version: 5.1.1
+    engines: {node: '>=8.0.0'}
+    dependencies:
+      esrecurse: registry.npmmirror.com/esrecurse/4.3.0
+      estraverse: registry.npmmirror.com/estraverse/4.3.0
     dev: false
 
   registry.npmmirror.com/eslint-scope/7.1.0:
@@ -784,6 +995,13 @@ packages:
     dependencies:
       estraverse: registry.npmmirror.com/estraverse/5.3.0
 
+  registry.npmmirror.com/estraverse/4.3.0:
+    resolution: {integrity: sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==, registry: https://registry.npm.taobao.org/, tarball: https://registry.npmmirror.com/estraverse/-/estraverse-4.3.0.tgz}
+    name: estraverse
+    version: 4.3.0
+    engines: {node: '>=4.0'}
+    dev: false
+
   registry.npmmirror.com/estraverse/5.3.0:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==, registry: https://registry.npm.taobao.org/, tarball: https://registry.npmmirror.com/estraverse/-/estraverse-5.3.0.tgz}
     name: estraverse
@@ -823,6 +1041,19 @@ packages:
     version: 3.1.3
     dev: true
 
+  registry.npmmirror.com/fast-glob/3.2.11:
+    resolution: {integrity: sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==, registry: https://registry.npm.taobao.org/, tarball: https://registry.npmmirror.com/fast-glob/-/fast-glob-3.2.11.tgz}
+    name: fast-glob
+    version: 3.2.11
+    engines: {node: '>=8.6.0'}
+    dependencies:
+      '@nodelib/fs.stat': registry.npmmirror.com/@nodelib/fs.stat/2.0.5
+      '@nodelib/fs.walk': registry.npmmirror.com/@nodelib/fs.walk/1.2.8
+      glob-parent: registry.npmmirror.com/glob-parent/5.1.2
+      merge2: registry.npmmirror.com/merge2/1.4.1
+      micromatch: registry.npmmirror.com/micromatch/4.0.4
+    dev: false
+
   registry.npmmirror.com/fast-json-stable-stringify/2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==, registry: https://registry.npm.taobao.org/, tarball: https://registry.npmmirror.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz}
     name: fast-json-stable-stringify
@@ -834,6 +1065,14 @@ packages:
     name: fast-levenshtein
     version: 2.0.6
     dev: true
+
+  registry.npmmirror.com/fastq/1.13.0:
+    resolution: {integrity: sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==, registry: https://registry.npm.taobao.org/, tarball: https://registry.npmmirror.com/fastq/-/fastq-1.13.0.tgz}
+    name: fastq
+    version: 1.13.0
+    dependencies:
+      reusify: registry.npmmirror.com/reusify/1.0.4
+    dev: false
 
   registry.npmmirror.com/figures/2.0.0:
     resolution: {integrity: sha512-Oa2M9atig69ZkfwiApY8F2Yy+tzMbazyvqv21R0NsSC8floSOC09BbT1ITWAdoMGQvJ/aZnR1KMwdx9tvHnTNA==, registry: https://registry.npm.taobao.org/, tarball: https://registry.npmmirror.com/figures/-/figures-2.0.0.tgz}
@@ -860,7 +1099,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       to-regex-range: registry.npmmirror.com/to-regex-range/5.0.1
-    dev: true
 
   registry.npmmirror.com/find-node-modules/2.1.2:
     resolution: {integrity: sha512-x+3P4mbtRPlSiVE1Qco0Z4YLU8WFiFcuWTf3m75OV9Uzcfs2Bg+O9N+r/K0AnmINBW06KpfqKwYJbFlFq4qNug==, registry: https://registry.npm.taobao.org/, tarball: https://registry.npmmirror.com/find-node-modules/-/find-node-modules-2.1.2.tgz}
@@ -920,7 +1158,15 @@ packages:
     resolution: {integrity: sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==, registry: https://registry.npm.taobao.org/, tarball: https://registry.npmmirror.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz}
     name: functional-red-black-tree
     version: 1.0.1
-    dev: true
+
+  registry.npmmirror.com/glob-parent/5.1.2:
+    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==, registry: https://registry.npm.taobao.org/, tarball: https://registry.npmmirror.com/glob-parent/-/glob-parent-5.1.2.tgz}
+    name: glob-parent
+    version: 5.1.2
+    engines: {node: '>= 6'}
+    dependencies:
+      is-glob: registry.npmmirror.com/is-glob/4.0.3
+    dev: false
 
   registry.npmmirror.com/glob-parent/6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==, registry: https://registry.npm.taobao.org/, tarball: https://registry.npmmirror.com/glob-parent/-/glob-parent-6.0.2.tgz}
@@ -1000,6 +1246,20 @@ packages:
       type-fest: registry.npmmirror.com/type-fest/0.20.2
     dev: true
 
+  registry.npmmirror.com/globby/11.1.0:
+    resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==, registry: https://registry.npm.taobao.org/, tarball: https://registry.npmmirror.com/globby/-/globby-11.1.0.tgz}
+    name: globby
+    version: 11.1.0
+    engines: {node: '>=10'}
+    dependencies:
+      array-union: registry.npmmirror.com/array-union/2.1.0
+      dir-glob: registry.npmmirror.com/dir-glob/3.0.1
+      fast-glob: registry.npmmirror.com/fast-glob/3.2.11
+      ignore: registry.npmmirror.com/ignore/5.2.0
+      merge2: registry.npmmirror.com/merge2/1.4.1
+      slash: registry.npmmirror.com/slash/3.0.0
+    dev: false
+
   registry.npmmirror.com/graceful-fs/4.2.9:
     resolution: {integrity: sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==, registry: https://registry.npm.taobao.org/, tarball: https://registry.npmmirror.com/graceful-fs/-/graceful-fs-4.2.9.tgz}
     name: graceful-fs
@@ -1050,7 +1310,6 @@ packages:
     name: ignore
     version: 5.2.0
     engines: {node: '>= 4'}
-    dev: true
 
   registry.npmmirror.com/import-fresh/3.3.0:
     resolution: {integrity: sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==, registry: https://registry.npm.taobao.org/, tarball: https://registry.npmmirror.com/import-fresh/-/import-fresh-3.3.0.tgz}
@@ -1123,7 +1382,6 @@ packages:
     name: is-extglob
     version: 2.1.1
     engines: {node: '>=0.10.0'}
-    dev: true
 
   registry.npmmirror.com/is-fullwidth-code-point/2.0.0:
     resolution: {integrity: sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==, registry: https://registry.npm.taobao.org/, tarball: https://registry.npmmirror.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz}
@@ -1139,14 +1397,12 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       is-extglob: registry.npmmirror.com/is-extglob/2.1.1
-    dev: true
 
   registry.npmmirror.com/is-number/7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==, registry: https://registry.npm.taobao.org/, tarball: https://registry.npmmirror.com/is-number/-/is-number-7.0.0.tgz}
     name: is-number
     version: 7.0.0
     engines: {node: '>=0.12.0'}
-    dev: true
 
   registry.npmmirror.com/is-utf8/0.2.1:
     resolution: {integrity: sha512-rMYPYvCzsXywIsldgLaSoPlw5PfoB/ssr7hY4pLfcodrA5M/eArza1a9VmTiNIBNMjOGr1Ow9mTyU2o69U6U9Q==, registry: https://registry.npm.taobao.org/, tarball: https://registry.npmmirror.com/is-utf8/-/is-utf8-0.2.1.tgz}
@@ -1273,6 +1529,13 @@ packages:
     version: 2.1.1
     dev: true
 
+  registry.npmmirror.com/merge2/1.4.1:
+    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==, registry: https://registry.npm.taobao.org/, tarball: https://registry.npmmirror.com/merge2/-/merge2-1.4.1.tgz}
+    name: merge2
+    version: 1.4.1
+    engines: {node: '>= 8'}
+    dev: false
+
   registry.npmmirror.com/micromatch/4.0.4:
     resolution: {integrity: sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==, registry: https://registry.npm.taobao.org/, tarball: https://registry.npmmirror.com/micromatch/-/micromatch-4.0.4.tgz}
     name: micromatch
@@ -1281,7 +1544,6 @@ packages:
     dependencies:
       braces: registry.npmmirror.com/braces/3.0.2
       picomatch: registry.npmmirror.com/picomatch/2.3.1
-    dev: true
 
   registry.npmmirror.com/mimic-fn/1.2.0:
     resolution: {integrity: sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==, registry: https://registry.npm.taobao.org/, tarball: https://registry.npmmirror.com/mimic-fn/-/mimic-fn-1.2.0.tgz}
@@ -1305,7 +1567,7 @@ packages:
     dev: true
 
   registry.npmmirror.com/ms/2.1.2:
-    resolution: {integrity: sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=, registry: https://registry.npm.taobao.org/, tarball: https://registry.npmmirror.com/ms/download/ms-2.1.2.tgz?cache=0&sync_timestamp=1632788163669&other_urls=https%3A%2F%2Fregistry.npmmirror.com%2Fms%2Fdownload%2Fms-2.1.2.tgz}
+    resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==, registry: https://registry.npm.taobao.org/, tarball: https://registry.npmmirror.com/ms/-/ms-2.1.2.tgz}
     name: ms
     version: 2.1.2
 
@@ -1400,15 +1662,12 @@ packages:
     name: path-type
     version: 4.0.0
     engines: {node: '>=8'}
-    dev: true
-    optional: true
 
   registry.npmmirror.com/picomatch/2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==, registry: https://registry.npm.taobao.org/, tarball: https://registry.npmmirror.com/picomatch/-/picomatch-2.3.1.tgz}
     name: picomatch
     version: 2.3.1
     engines: {node: '>=8.6'}
-    dev: true
 
   registry.npmmirror.com/prelude-ls/1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==, registry: https://registry.npm.taobao.org/, tarball: https://registry.npmmirror.com/prelude-ls/-/prelude-ls-1.2.1.tgz}
@@ -1424,12 +1683,17 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
+  registry.npmmirror.com/queue-microtask/1.2.3:
+    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==, registry: https://registry.npm.taobao.org/, tarball: https://registry.npmmirror.com/queue-microtask/-/queue-microtask-1.2.3.tgz}
+    name: queue-microtask
+    version: 1.2.3
+    dev: false
+
   registry.npmmirror.com/regexpp/3.2.0:
     resolution: {integrity: sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==, registry: https://registry.npm.taobao.org/, tarball: https://registry.npmmirror.com/regexpp/-/regexpp-3.2.0.tgz}
     name: regexpp
     version: 3.2.0
     engines: {node: '>=8'}
-    dev: true
 
   registry.npmmirror.com/resolve-dir/1.0.1:
     resolution: {integrity: sha512-R7uiTjECzvOsWSfdM0QKFNBVFcK27aHOUwdvK53BcW8zqnGdYp0Fbj82cy54+2A4P2tFM22J5kRfe1R+lM/1yg==, registry: https://registry.npm.taobao.org/, tarball: https://registry.npmmirror.com/resolve-dir/-/resolve-dir-1.0.1.tgz}
@@ -1476,6 +1740,13 @@ packages:
       signal-exit: registry.npmmirror.com/signal-exit/3.0.6
     dev: true
 
+  registry.npmmirror.com/reusify/1.0.4:
+    resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==, registry: https://registry.npm.taobao.org/, tarball: https://registry.npmmirror.com/reusify/-/reusify-1.0.4.tgz}
+    name: reusify
+    version: 1.0.4
+    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+    dev: false
+
   registry.npmmirror.com/rimraf/3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==, registry: https://registry.npm.taobao.org/, tarball: https://registry.npmmirror.com/rimraf/-/rimraf-3.0.2.tgz}
     name: rimraf
@@ -1491,6 +1762,14 @@ packages:
     version: 2.4.1
     engines: {node: '>=0.12.0'}
     dev: true
+
+  registry.npmmirror.com/run-parallel/1.2.0:
+    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==, registry: https://registry.npm.taobao.org/, tarball: https://registry.npmmirror.com/run-parallel/-/run-parallel-1.2.0.tgz}
+    name: run-parallel
+    version: 1.2.0
+    dependencies:
+      queue-microtask: registry.npmmirror.com/queue-microtask/1.2.3
+    dev: false
 
   registry.npmmirror.com/rxjs/6.6.7:
     resolution: {integrity: sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==, registry: https://registry.npm.taobao.org/, tarball: https://registry.npmmirror.com/rxjs/-/rxjs-6.6.7.tgz}
@@ -1538,6 +1817,13 @@ packages:
     name: signal-exit
     version: 3.0.6
     dev: true
+
+  registry.npmmirror.com/slash/3.0.0:
+    resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==, registry: https://registry.npm.taobao.org/, tarball: https://registry.npmmirror.com/slash/-/slash-3.0.0.tgz}
+    name: slash
+    version: 3.0.0
+    engines: {node: '>=8'}
+    dev: false
 
   registry.npmmirror.com/string-width/2.1.1:
     resolution: {integrity: sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==, registry: https://registry.npm.taobao.org/, tarball: https://registry.npmmirror.com/string-width/-/string-width-2.1.1.tgz}
@@ -1643,7 +1929,6 @@ packages:
     engines: {node: '>=8.0'}
     dependencies:
       is-number: registry.npmmirror.com/is-number/7.0.0
-    dev: true
 
   registry.npmmirror.com/ts-node/10.4.0_typescript@4.5.5:
     resolution: {integrity: sha512-g0FlPvvCXSIO1JDF6S232P5jPYqBkRL9qly81ZgAOSU7rwI0stphCgd2kLiCrU9DjQCrJMWEqcNSjQL02s6d8A==, registry: https://registry.npm.taobao.org/, tarball: https://registry.npmmirror.com/ts-node/-/ts-node-10.4.0.tgz}
@@ -1682,7 +1967,17 @@ packages:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==, registry: https://registry.npm.taobao.org/, tarball: https://registry.npmmirror.com/tslib/-/tslib-1.14.1.tgz}
     name: tslib
     version: 1.14.1
-    dev: true
+
+  registry.npmmirror.com/tsutils/3.21.0:
+    resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==, registry: https://registry.npm.taobao.org/, tarball: https://registry.npmmirror.com/tsutils/-/tsutils-3.21.0.tgz}
+    name: tsutils
+    version: 3.21.0
+    engines: {node: '>= 6'}
+    peerDependencies:
+      typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
+    dependencies:
+      tslib: registry.npmmirror.com/tslib/1.14.1
+    dev: false
 
   registry.npmmirror.com/type-check/0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==, registry: https://registry.npm.taobao.org/, tarball: https://registry.npmmirror.com/type-check/-/type-check-0.4.0.tgz}


### PR DESCRIPTION
**引入的其他包规则**
`typescript-eslint/recommended`

**添加的规则**
| 规则                                    | 说明                                                         |
| --------------------------------------- | ------------------------------------------------------------ |
| lines-between-class-members             | 在类重载后不跳过检查空行                                     |
| no-confusing-non-null-assertion         | 禁止使用容易混淆的非空断言                                   |
| prefer-nullish-coalescing               | 使用可选链式表达式而不是逻辑与运算符<br />比如：使用 a?.b 代替 a && a.b，语法上更简洁 |
| no-non-null-asserted-nullish-coalescing | 不允许非空断言与空值合并同时使用                             |
| space-infix-ops                         | 运算符两侧需要有空格，并增加对枚举类型支持                   |
| keyword-spacing                         | 关键字前后有一个空格，并增加了对函数调用的泛型类型参数的支持 |
| type-annotation-spacing                 | 调用函数时，函数名与括号之间没有空格，并增加了对函数调用的泛型类型参数的支持 |
| func-call-spacing                       | 变量命名不能和关键字同名                                     |
| comma-spacing                           | 逗号前面没空格，后面有空格                                   |
| space-before-function-paren             | 增加了对函数调用的泛型类型参数的支持                         |
| member-delimiter-style                  | interface 和 type 里的成员统一使用分号（;）进行分割，单行类型的最后一个元素不加分号 |
| brace-style                             | 对于非空代码块，采用 Egyptian Brackets 风格                  |
| no-array-constructor                    | 不要使用 new Array() 和 Array() 创建数组，除非为了构造某一长度的空数组 |
| no-unused-vars                          | 使用的变量                                                   |
| ban-types                               | 禁止部分值被作为类型标注，需要对每一种被禁用的类型提供特定的说明 |
| no-confusing-void-expression            | 不允许返回一个类型是 void 的表达式                           |
| no-inferrable-types                     | 不允许不必要的类型标注，但允许类的属性成员进行额外标注       |
| no-unnecessary-type-arguments           | 使用泛型时，不允许指定与默认类型参数一致的类型参数           |
| no-unnecessary-type-constraint          | 不允许与默认约束一致的泛型约束<br />在 TS 3.9 版本以后，对于未指定的泛型约束，默认使用 unknown ，在这之前则是 any |
| no-non-null-asserted-optional-chain     | 不允许非空断言与可选链同时使用                               |
| prefer-for-of                           | 如果索引仅用于访问正在迭代的数组，则首选 for...of 而不是 for 循环遍历数组 |
| adjacent-overload-signatures            | 重载的函数写在一起                                           |
| default-param-last                      | 具有默认值的函数参数应该被放置到参数列表右边                 |
| explicit-member-accessibility           | 设置类的成员的可访问性，public 可省略                        |
| prefer-literal-enum-member              | 对于枚举成员值，只允许使用普通字符串、数字、null、正则，而不允许变量复制、模板字符串等需要计算的操作 |
| await-thenable                          | 只允许对异步函数、Promise、PromiseLike 使用 await 调用       |
| promise-function-async                  | 返回 Promise 的函数必须被标记为 async                        |
| consistent-type-imports                 | 约束使用 import type {} 进行类型的导入                       |
| no-duplicate-imports                    | 不允许对同一模块重复导入，类型可重复导入                     |
| prefer-namespace-keyword                | 禁止使用 module 来定义命名空间                               |
| method-signature-style                  | 接口中的方法使用属性的方式定义。使用属性去定义接口中的方法，可以获得更严格的检查 |
| no-empty-interface                      | 不允许定义空的接口，允许单继承下的空接口                     |
| consistent-type-definitions             | 对于对象类型，优先使用 interface 定义                        |
| no-extra-non-null-assertion             | 不允许额外的非空断言                                         |
| no-unnecessary-type-assertion           | 不允许与实际值一致的类型断言                                 |
| non-nullable-type-assertion-style       | 首选非空断言而不是显式类型转换                               |
| consistent-type-assertions              | 使用 as 进行类型断言而不是 <>                                |
| ban-tslint-comment                      | 禁止使用 `tslint:<rule-flag>` 等相关注释，tslint 已经不再维护了 |
| ban-ts-comment                          | 禁止使用其他 @ts 规则，除非提供必要的说明                    |
| prefer-ts-expect-error                  | 推荐使用 ts-expect-error 而不是 ts-ignore                    |






